### PR TITLE
Update 07-raster-calculations.md

### DIFF
--- a/_episodes/07-raster-calculations.md
+++ b/_episodes/07-raster-calculations.md
@@ -173,6 +173,7 @@ instead.
 import xarray
 from matplotlib.colors import ListedColormap
 import earthpy.plot as ep
+import numpy as np
 
 # Defines the bins for pixel values
 class_bins = [canopy_HARV.min().values, 2, 10, 20, np.inf]


### PR DESCRIPTION
numpy is required for the 'Classifying Continuous Rasters in Python' example

There is reference to both np.inf and np.digitize throwing error: NameError: name 'np' is not define