### PR TITLE
Lesson Contribution: Update geospatial environment activation session

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -258,19 +258,27 @@ code on the Terminal:
     > /Users/your-username/anaconda3/envs/geospatial/bin/python
                                           ^^^^^^^^^^
     ```
-
+    
     > ## IMPORTANT
     > If you close the terminal, you will need to 
     reactivate this environment with `conda activate geospatial` to use the Python libraries required for the lesson and
    > to start JupyterLab, which is also installed in the `geospatial` environment.
     {: .callout}
-
+    
 
 ## Starting JupyterLab
 
 In order to follow the lessons on using Python (episode 5 and onward), you should launch JupyterLab 
 after activating the geospatial conda environment in your working directory that contains the data you downloaded. 
-See [Starting JupyterLab][starting-jupyterlab] for guidance.
+See [Starting JupyterLab][starting-jupyterlab] for guidance or enter the code snippet below:
+   ```bash
+   jupyter lab
+   ```
+  
+Once you have opened a new Jupyter Lab file, confirm that all modules have been installed correctly by importing a module:
+    ```
+    import rioxarray
+    ```
 
 If all of the steps above completed successfully you are ready to follow along with the lesson!
 


### PR DESCRIPTION
I'm a member of The Carpentries Core Team and I'm submitting this issue on behalf of another member of the community. In most cases, I won't be able to follow up or provide more details other than what I'm providing below.

---


I added instructions to open the Jupyter Lab notebook and attempt importing a module (rioxarray). Rioxarray is used in Episode #1 and we often find that learners aren't able to import it. By adding this step to the Setup page, learners can attempt the import during office hours so we don't have to dedicate helpers to assisting with minor setup issues. Lines 274-281.
