### PR TITLE
Typo: calling numpy method on xarray object

### DIFF
--- a/_episodes/05-raster-structure.md
+++ b/_episodes/05-raster-structure.md
@@ -352,7 +352,7 @@ Coordinates:
 > {: .output}
 > You may notice that `surface_HARV.quantile` and `numpy.percentile` didn't require an argument specifying the axis or dimension along which to compute the quantile. This is because `axis=None` is the default for most numpy 
 > functions, and therefore `dim=None` is the default for most xarray methods. It's always good to check out the docs on a function to see what the default arguments are, particularly when working with 
-> multi-dimensional image data. To do so, we can use`help(surface_HARV.quantile)` or `?surface_HARV.percentile` if you are using jupyter notebook or 
+> multi-dimensional image data. To do so, we can use`help(surface_HARV.quantile)` or `?surface_HARV.quantile` if you are using jupyter notebook or 
 > jupyter lab.
 > 
 {: .callout}


### PR DESCRIPTION
Switch to call quantile rather than percentile on xarray image.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
