### PR TITLE
Remove pinning on old version of `pystac-client`

### DIFF
--- a/files/environment.yaml
+++ b/files/environment.yaml
@@ -16,5 +16,5 @@ dependencies:
   - earthpy>=0.9.0
   - xarray-spatial
   - descartes>=1.0.0 # necessary for geopandas plotting
-  - pystac-client==0.3.2 # pin version to work with earth-search STAC API
+  - pystac-client>=0.5.1
   - python-graphviz # necessary for plotting dask graphs

--- a/setup.md
+++ b/setup.md
@@ -171,7 +171,7 @@ code on the Terminal:
     ```bash
     conda create -n geospatial -c conda-forge -y \
       jupyterlab numpy matplotlib \
-      xarray rasterio geopandas rioxarray earthpy descartes xarray-spatial pystac-client==0.3.2 python-graphviz
+      xarray rasterio geopandas rioxarray earthpy descartes xarray-spatial pystac-client python-graphviz
 
     ```
 
@@ -209,7 +209,7 @@ code on the Terminal:
       - xarray-spatial
       - earthpy
       - descartes # necessary for geopandas plotting
-      - pystac-client==0.3.2 # pin version to work with earth-search STAC API
+      - pystac-client
       - python-graphviz
     ```
 


### PR DESCRIPTION
Previous issues with the Earth Search STAC endpoint are solved in the newer versions of `pystac-client`:

https://github.com/cirrus-geo/cirrus-earth-search/issues/28