### PR TITLE
switch to use COG overviews visual asset for ep 6, remove ref to overview asset

### DIFF
--- a/_episodes/06-raster-intro.md
+++ b/_episodes/06-raster-intro.md
@@ -401,7 +401,7 @@ So far we looked into a single band raster, i.e. the `nir09` band of a Sentinel-
 
 The `overview` asset in the Sentinel-2 scene is a multiband asset. Similar to `nir09`, we can load it by:
 ~~~
-raster_ams_overview = rioxarray.open_rasterio(items[0].assets['overview'].href)
+raster_ams_overview = rioxarray.open_rasterio(items[0].assets['visual'].href, overview_level=3)
 raster_ams_overview
 ~~~
 {: .language-python}


### PR DESCRIPTION
@fnattino thanks for noting the leftover use of overview, fixed here!

addresses #146 

Still need to check episodes past episode 8.
