### PR TITLE
Fix `make docker-serve`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ and submitting [bug reports][issues]
 about things that don't work, aren't clear, or are missing.
 If you are looking for ideas, please see the 'Issues' tab for
 a list of issues associated with this repository,
-or you may also look at the issues for [Data Carpentry][dc-issues], 
+or you may also look at the issues for [Data Carpentry][dc-issues],
 [Software Carpentry][swc-issues], and [Library Carpentry][lc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome:
@@ -86,7 +86,7 @@ so fresh eyes are always welcome.
 ## What *Not* to Contribute
 
 Our lessons already contain more material than we can cover in a typical workshop,
-so we are usually *not* looking for more concepts or tools to add to them (but for this 
+so we are usually *not* looking for more concepts or tools to add to them (but for this
 geospatial incubator lesson, we are looking for this since it is in alpha!).
 As a rule,
 if you want to introduce a new idea,
@@ -109,16 +109,31 @@ Each lesson has two maintainers who review issues and pull requests or encourage
 The maintainers are community volunteers and have final say over what gets merged into the lesson.
 To use the web interface for contributing to a lesson:
 
-1.  Fork the originating repository to your GitHub profile.
-2.  Within your version of the forked repository, move to the `gh-pages` branch and
+1. Fork the originating repository to your GitHub profile.
+1. Within your version of the forked repository, move to the `gh-pages` branch and
 create a new branch for each significant change being made.
-3.  Navigate to the file(s) you wish to change within the new branches and make revisions as required.
-4.  Commit all changed files within the appropriate branches.
-5.  Create individual pull requests from each of your changed branches
+1. Navigate to the file(s) you wish to change within the new branches and make revisions as required.
+1. Verify your changes by launching a local web server to view changes in a browser
+   by doing the following:
+   1. Install [Docker], if not already installed
+   1. Run Docker, if not already running
+   1. From the root of your repository, run the following command:
+      `make docker-serve`
+   1. Wait for the server to startup (about 10-15 seconds), until you see the
+      message `Server running... press ctrl-c to stop.`
+   1. Open a browser to <http://localhost:4000> and navigate to the pages that
+      you changed (or added) to confirm that your changes are rendered as you
+      expect.  (Note that if you make changes while the server is running, they
+      will be reloaded in your browser automatically because the server is
+      started with "live reload" enabled.)
+   1. When you are satisfied with your changes, you may press ctrl-c to stop
+      the server.
+1. Commit all changed files within the appropriate branches.
+1. Create individual pull requests from each of your changed branches
 to the `gh-pages` branch within the originating repository.
-6.  If you receive feedback, make changes using your issue-specific branches of the forked
+1. If you receive feedback, make changes using your issue-specific branches of the forked
 repository and the pull requests will update automatically.
-7.  Repeat as needed until all feedback has been addressed.
+1. Repeat as needed until all feedback has been addressed.
 
 When starting work, please make sure your clone of the originating `gh-pages` branch is up-to-date
 before creating your own revision-specific branch(es) from there.
@@ -139,6 +154,7 @@ You can also [reach us by email][email].
 [dc-lessons]: http://datacarpentry.org/lessons/
 [dc-site]: http://datacarpentry.org/
 [discuss-list]: http://lists.software-carpentry.org/listinfo/discuss
+[docker]: https://www.docker.com/
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+ARG JEKYLL_VERSION
+FROM jekyll/jekyll:${JEKYLL_VERSION}
+
+WORKDIR /srv/jekyll
+COPY Gemfile .
+RUN bundle install

--- a/_episodes/01-intro-raster-data.md
+++ b/_episodes/01-intro-raster-data.md
@@ -31,8 +31,8 @@ Earth's surface, and
 assign attributes to those features. Vector data structures
 will be discussed in more detail in [the next episode]({{site.baseurl}}/02-intro-vector-data).
 
-This workshop will focus on how to work with both raster and vector 
-data sets, therefore it is essential that we understand the 
+This workshop will focus on how to work with both raster and vector
+data sets, therefore it is essential that we understand the
 basic structures of these types of data and the types of data
 that they can be used to represent.
 
@@ -84,37 +84,36 @@ information. Photogrammetric Engineering and Remote Sensing, v. 81, no. 5, p.
 345-354)
 
 > ## Advantages and Disadvantages
-> 
+>
 > With your neighbor, brainstorm potential advantages and
 > disadvantages of storing data in raster format. Add your
 > ideas to the Etherpad. The Instructor will discuss and
 > add any points that weren't brought up in the small group
-> discussions. 
-> 
+> discussions.
+>
 > > ## Solution
 > >
 > > Raster data has some important advantages:
-> > 
+> >
 > > * representation of continuous surfaces
 > > * potentially very high levels of detail
-> > * data is 'unweighted' across its extent - the geometry doesn't 
+> > * data is 'unweighted' across its extent - the geometry doesn't
 > > implicitly highlight features
 > > * cell-by-cell calculations can be very fast and efficient
-> > 
+> >
 > > The downsides of raster data are:
-> > 
+> >
 > > * very large file sizes as cell size gets smaller
 > > * currently popular formats don't embed metadata well (more on this later!)
 > > * can be difficult to represent complex information
 > {: .solution}
 {: .challenge}
 
-
 ## Important Attributes of Raster Data
 
 ### Extent
 
-The spatial extent is the geographic area that the raster data covers. 
+The spatial extent is the geographic area that the raster data covers.
 The spatial extent of an object represents the geographic edge or
 location that is the furthest north, south, east and west. In other words, extent
 represents the overall geographic coverage of the spatial object.
@@ -125,15 +124,15 @@ represents the overall geographic coverage of the spatial object.
 {: .text-center}
 
 > ## Extent Challenge
-> 
-> In the image above, the dashed boxes around each set of objects 
-> seems to imply that the three objects have the same extent. Is this 
+>
+> In the image above, the dashed boxes around each set of objects
+> seems to imply that the three objects have the same extent. Is this
 > accurate? If not, which object(s) have a different extent?
-> 
+>
 > > ## Solution
 > >
 > > The lines and polygon objects have the same extent. The extent for
-> > the points object is smaller in the vertical direction than the 
+> > the points object is smaller in the vertical direction than the
 > > other two because there are no points on the line at y = 8.
 > {: .solution}
 {: .challenge}
@@ -142,7 +141,7 @@ represents the overall geographic coverage of the spatial object.
 
 A resolution of a raster represents the area on the ground that each
 pixel of the raster covers. The image below illustrates the effect
-of changes in resolution. 
+of changes in resolution.
 
 ![Resolution image](../fig/E01-05-raster_resolution.png)
 
@@ -167,7 +166,7 @@ as tags. These tags should include the following raster metadata:
    concept in [a later episode]({{site.baseurl}}/06-raster-intro).
 
 We will discuss these attributes in more detail in [a later
-episode](({{site.baseurl}}/06-raster-intro).
+episode]({{site.baseurl}}/06-raster-intro).
 In that episode, we will also learn how to use Python to extract raster attributes
 from a GeoTIFF file.
 
@@ -202,14 +201,14 @@ In a multi-band dataset, the rasters will always have the same extent,
 resolution, and CRS.
 
 > ## Other Types of Multi-band Raster Data
-> 
+>
 > Multi-band raster data might also contain:
-> 
-> 1. **Time series:** the same variable, over the same area, over time. 
+>
+> 1. **Time series:** the same variable, over the same area, over time.
 > 2. **Multi or hyperspectral imagery:** image rasters that have 4 or
 > more (multi-spectral) or more than 10-15 (hyperspectral) bands. We
 > won't be working with this type of data in this workshop, but you can
-> check out the NEON Data Skills 
+> check out the NEON Data Skills
 > [Imaging Spectroscopy HDF5 in R](https://www.neonscience.org/hsi-hdf5-r)
 > tutorial if you're interested in working with hyperspectral data cubes.
 {: .callout}


### PR DESCRIPTION
Make `make docker-serve` work when only Docker is installed (and
running), and add basic instructions to `CONTRIBUTING.md` for viewing
changes locally.

Also, fix broken "a later episode" link in
`_episodes/01-intro-raster-data.md`.

Fixes #150