### PR TITLE
Update 05-access-data.md

### DIFF
--- a/_episodes/05-access-data.md
+++ b/_episodes/05-access-data.md
@@ -104,7 +104,7 @@ client = Client.open(api_url)
 ~~~
 {: .language-python}
 
-In the following, we ask for scenes belonging to the `sentinel-s2-l2a-cogs` collection. This dataset includes Sentinel-2
+In the following, we ask for scenes belonging to the `sentinel-2-l2a` collection. This dataset includes Sentinel-2
 data products pre-processed at level 2A (bottom-of-atmosphere reflectance) and saved in Cloud Optimized GeoTIFF (COG)
 format:
 


### PR DESCRIPTION
Minor fix to correct the sentinel l2 collection short name used in the explanatory text. I think `sentinel-s2-l2a-cogs` is an old short name and is intended to be `sentinel-2-l2a` which is used in the exercises.