### PR TITLE
Fix internal link in setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -117,7 +117,7 @@ command in your terminal (use the **Anaconda prompt** on **Windows**).
    conda install -c conda-forge mamba
    ```
 
-   IMPORTANT: If your terminal responds to the above command with `conda: command not found` see the > <<troubleshooting>> section.
+   IMPORTANT: If your terminal responds to the above command with `conda: command not found` see the [Troubleshooting section](index.md#troubleshooting-conda-command-not-found).
 
 3. Create the Python environment for the workshop by running:
 

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -117,7 +117,7 @@ command in your terminal (use the **Anaconda prompt** on **Windows**).
    conda install -c conda-forge mamba
    ```
 
-   IMPORTANT: If your terminal responds to the above command with `conda: command not found` see the [Troubleshooting section](index.md#troubleshooting-conda-command-not-found).
+   IMPORTANT: If your terminal responds to the above command with `conda: command not found` see the [Troubleshooting section](#troubleshooting-conda-command-not-found).
 
 3. Create the Python environment for the workshop by running:
 


### PR DESCRIPTION
For some reason using the `setup.md` file  as target in the link does not seem to work, but referencing `index.md` does the job.